### PR TITLE
Feature/113 smaller cards on home page

### DIFF
--- a/src/views/home/Home.tsx
+++ b/src/views/home/Home.tsx
@@ -1,59 +1,38 @@
 import React from 'react';
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { Box } from '@mui/material';
+import { Grid } from '@mui/material';
 
 import MenuCard from './MenuCard';
 
-const HomeContainer = styled('div')({
+const HomePageContainer = styled('div')({
   width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-});
-
-const InfoContainer = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  textAlign: 'center',
-  width: '100%',
   padding: '4rem',
 });
 
-const CardButtonsContainer = styled(Box)(({ theme }) => ({
+const HomeTitleContainer = styled('div')({
+  justifyContent: 'left',
+  textAlign: 'left',
   width: '100%',
-  maxWidth: 1300,
-  height: 1100,
-  padding: 10,
-  display: 'flex',
-  flexWrap: 'wrap',
-  flexDirection: 'row',
-  justifyContent: 'space-around',
-  [theme.breakpoints.down('md')]: {
-    flexDirection: 'column',
-    height: 'auto',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-}));
+  'padding-bottom': '2rem',
+});
 
 const Home: React.FC = () => {
   return (
-    <HomeContainer>
-      <InfoContainer>
+    <HomePageContainer>
+      <HomeTitleContainer>
         <Typography variant="h1">New Zealand National Seismic Hazard Model</Typography>
-        <Typography>Welcome to the New Zealand NSHM. This is the 2022 revision to the model. Here’s a link back to the explanation and background info on the model.</Typography>
-      </InfoContainer>
-      <CardButtonsContainer>
-        {/*<MenuCard title="Hazard Curves" text="Hazard Curves to view" img="/images/HazardChart.png" url="/Hazardcurves" />*/}
-        <MenuCard title="Hazard Curves" text="Hazard Curves to view" img="/images/SpectralAccelChart.png" url="/Hazardcurves" />
-        <MenuCard title="Hazard Maps" text="Hazard Maps to view" img="/images/HazardMapExample.png" url="/HazardMaps" />
-        {/*<MenuCard title="Rupture Sets" text="Rupture Sets to view" img="/ruptureSets.png" url="/" />*/}
-        <MenuCard title="Resources" text="Model Information, Reports, and Input Files" img="/info.jpg" url="/Resources" />
-      </CardButtonsContainer>
-    </HomeContainer>
+        <Typography>Welcome to the 2022 revision of the NSHM model. Here’s a link back to the explanation and background info on the model.</Typography>
+      </HomeTitleContainer>
+      <Grid container spacing={6} columns={{ sm: 6, md: 8, lg: 12 }}>
+        <MenuCard title="Hazard Curves" text="Hazard and Spectral acceleration plots." img="/images/SpectralAccelChart.png" url="/Hazardcurves" />
+        <MenuCard title="Hazard Maps" text="Showing gridded hazard levels across NZ." img="/images/HazardMapExample.png" url="/HazardMaps" />
+        <MenuCard title="Rupture Sets" text="Ruptures and seismic event rates." img="/images/TUI-ruptures-0.png" url="/Previews" />
+        <MenuCard title="Resources" text="Model information, reports, and datsets." img="/info.jpg" url="/Resources" />
+      </Grid>
+    </HomePageContainer>
   );
 };
 

--- a/src/views/home/MenuCard.tsx
+++ b/src/views/home/MenuCard.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import { CardActionArea, styled } from '@mui/material';
+import { CardActionArea } from '@mui/material';
+import Grid from '@mui/material/Grid';
 import { Card, CardContent, CardMedia, CardActions, Typography, Button } from '@mui/material';
 import { Link } from 'react-router-dom';
-
-const StyledCard = styled(Card)(({ theme }) => ({
-  width: '45%',
-  height: '40%',
-  [theme.breakpoints.down('md')]: {
-    width: '80%',
-    margin: 30,
-  },
-}));
 
 interface MenuCardProps {
   title: string;
@@ -21,20 +13,22 @@ interface MenuCardProps {
 
 const MenuCard: React.FC<MenuCardProps> = ({ title, text, img, url }: MenuCardProps) => {
   return (
-    <StyledCard>
-      <CardActionArea component={Link} to={url}>
-        <CardContent>
-          <Typography variant="h5">{title}</Typography>
-          <Typography>{text}</Typography>
-        </CardContent>
-        <CardMedia component="img" height="300px" image={img} />
-        <CardActions>
-          <Button size="small" component={Link} to={url}>
-            More
-          </Button>
-        </CardActions>
-      </CardActionArea>
-    </StyledCard>
+    <Grid item xs={3}>
+      <Card>
+        <CardActionArea component={Link} to={url}>
+          <CardContent>
+            <Typography variant="h5">{title}</Typography>
+            <Typography>{text}</Typography>
+          </CardContent>
+          <CardMedia component="img" height="250px" image={img} sx={{ objectFit: 'cover' }} />
+          <CardActions>
+            <Button size="small" component={Link} to={url}>
+              More
+            </Button>
+          </CardActions>
+        </CardActionArea>
+      </Card>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
move to MUI Grid for card layout; make styling similar to /Previews

NB this branch should be rebased after #112  is merged to deploy-test