### PR TITLE
Fix/number of ticks

### DIFF
--- a/src/views/hazardCharts/HazardCharts.tsx
+++ b/src/views/hazardCharts/HazardCharts.tsx
@@ -112,7 +112,7 @@ const HazardCharts: React.FC<HazardChartsProps> = ({ data, state, dispatch }: Ha
               xLabel="Acceleration (g)"
               yLabel="Annual Probability of Exceedance"
               xLimits={
-                state.hazardXScale === "linear" ? [HAZARD_GMIN, HAZARD_GMAX] : [HAZARD_GMIN_LOG, HAZARD_GMAX_LOG]
+                state.hazardXScale === "linear" ? [HAZARD_GMIN, HAZARD_GMAX] : [HAZARD_GMIN_LOG, 5]
               }
               yLimits={[HAZARD_POEMIN, HAZARD_POEMAX]}
               tooltip={true}
@@ -122,6 +122,7 @@ const HazardCharts: React.FC<HazardChartsProps> = ({ data, state, dispatch }: Ha
               poe={state.poe}
               uncertainty={state.hazardUncertainty}
               timePeriod={state.timePeriod}
+              numTickX={state.hazardXScale === "linear" ? null : 2}
             />
           </div>
         </ChartContainer>
@@ -148,6 +149,7 @@ const HazardCharts: React.FC<HazardChartsProps> = ({ data, state, dispatch }: Ha
                 poe={state.poe}
                 uncertainty={state.spectralUncertainty}
                 timePeriod={state.timePeriod}
+                numTickX={state.spectraXScale === "linear" ? null : 2}
               />
             </div>
           </ChartContainer>

--- a/src/views/hazardCharts/HazardCharts.tsx
+++ b/src/views/hazardCharts/HazardCharts.tsx
@@ -112,7 +112,7 @@ const HazardCharts: React.FC<HazardChartsProps> = ({ data, state, dispatch }: Ha
               xLabel="Acceleration (g)"
               yLabel="Annual Probability of Exceedance"
               xLimits={
-                state.hazardXScale === "linear" ? [HAZARD_GMIN, HAZARD_GMAX] : [HAZARD_GMIN_LOG, 5]
+                state.hazardXScale === "linear" ? [HAZARD_GMIN, HAZARD_GMAX] : [HAZARD_GMIN_LOG, HAZARD_GMAX_LOG]
               }
               yLimits={[HAZARD_POEMIN, HAZARD_POEMAX]}
               tooltip={true}


### PR DESCRIPTION
After deploying to test I found that the settings for the hazard chart x-axis limits resulted in too many tick marks and overlapping tick labels. This PR sets the number of ticks to 2 when the x-axis is logarithmic.

# Before
<img width="930" height="358" alt="image" src="https://github.com/user-attachments/assets/149d0dff-c450-4959-9971-ada23562a778" />



# After
<img width="930" height="358" alt="image" src="https://github.com/user-attachments/assets/316896f7-322e-423d-923a-3f5d95d653e2" />



